### PR TITLE
Hide stylesheet without need for .ct class

### DIFF
--- a/ct.css
+++ b/ct.css
@@ -276,7 +276,7 @@ head > meta[charset]:not(:nth-child(-n+5))::before {
  */
 
 link[rel="stylesheet"][media="print"],
-link[rel="stylesheet"].ct, style.ct,
+link[rel="stylesheet"].ct, style.ct, link[rel="stylesheet"][href$="/ct.css"],
 script[async], script[defer], script[type=module] {
   display: none;
 }


### PR DESCRIPTION
I added a style which hides any stylesheet specifically named `ct.css`.

This has less coverage than using the class (the stylesheet MUST be named ct.css) but it allows for easier drop in use for tools or CMS's like WordPress, where adding a class to the stylesheet requires additional filtering.

What this allows in WordPress:
```php
if ( wp_get_environment_type() !== 'production' ) { // prevents showing on production sites, set environment type in wp-config
  wp_enqueue_style( 'ct', 'https://csswizardry.com/ct/ct.css', array(), null );
}
```