### PR TITLE
Remove 🧠 emoji from title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, minimum-scale=1.0" />
 
-  <title>🧠 ct.css – Let’s take a look inside your &lt;head&gt;</title>
+  <title>ct.css – Let’s take a look inside your &lt;head&gt;</title>
 
   <script>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
Hey there!

I feel like the double 🧠 looks a bit weird in Chrome and thought it would be good to remove the one from the `<title>`.

It is interesting though that Safari doesn't have the same issue:

![A screenshot of the ct.css website tabs in both Chrome and Safari. The Chrome tab has a brain emoji for a favicon and the title of the tab starts with a brain emoji as well. The Safari tab has a CSS favicon as well as the brain emoji as the first character of the title.](https://github.com/csswizardry/ct/assets/318208/44e4afd4-4dea-49ac-b5bd-8628e252df1d)

Anyway, I thought I'd let you know and it's easiest with a quick PR. Feel free to close it if you don't want to merge it! :)